### PR TITLE
[Chore]: Argo Image Updater image bump

### DIFF
--- a/infra/website-chart/.argocd-source-website-astro.yaml
+++ b/infra/website-chart/.argocd-source-website-astro.yaml
@@ -1,0 +1,8 @@
+helm:
+  parameters:
+  - name: image.name
+    value: 88lexd/website-astro
+    forcestring: true
+  - name: image.tag
+    value: v1.1.0
+    forcestring: true


### PR DESCRIPTION
updates image 88lexd/website-astro tag 'v1.0.0' to 'v1.1.0'

## Confirmation
The following are some requirements and reminders

- [ ] PR title must start with `[Chore | Fix | Docs | Minor | Major]`
